### PR TITLE
Fix for unite_api branch for API key specification without explicit history target.

### DIFF
--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -173,7 +173,9 @@ def _get_target_history(trans, workflow, payload, param_keys=[], index=0):
             history_id = history_param[ 8: ]
         else:
             history_name = history_param
-    if history_name is not None:
+
+    trans_history = trans.history
+    if history_name is not None or (history_id is None and trans_history is None):
         if history_name:
             nh_name = history_name
         else:
@@ -191,9 +193,10 @@ def _get_target_history(trans, workflow, payload, param_keys=[], index=0):
         target_history = new_history
     elif history_id:
         history_manager = histories.HistoryManager( trans.app )
-        target_history = history_manager.get_owned( trans.security.decode_id(history_id), trans.user, current_history=trans.history )
+        target_history = history_manager.get_owned( trans.security.decode_id(history_id), trans.user, current_history=trans_history )
     else:
-        target_history = trans.history
+        target_history = trans_history
+
     return target_history
 
 


### PR DESCRIPTION
It is good to not depend on trans.history being set I think and this is required to fix bioblend tests.
