### PR TITLE
Remove handle_panel_update

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -242,16 +242,6 @@ class ToolBox(BaseGalaxyToolBox):
             app=app,
         )
 
-    def handle_panel_update(self, section_dict):
-        """
-        Sends a panel update to all threads/processes.
-        """
-        send_control_task(self.app, 'create_panel_section', kwargs=section_dict)
-        # The following local call to self.create_section should be unnecessary
-        # but occasionally the local ToolPanelElements instance appears to not
-        # get updated.
-        self.create_section(section_dict)
-
     def has_reloaded(self, other_toolbox):
         return self._reload_count != other_toolbox._reload_count
 

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -98,13 +98,6 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             self._load_tool_panel()
         self._save_integrated_tool_panel()
 
-    def handle_panel_update(self, section_dict):
-        """Extension-point for Galaxy-app specific reload logic.
-
-        This abstract representation of the toolbox shouldn't have details about
-        interacting with the rest of the Galaxy app or message queues, etc....
-        """
-
     def create_tool(self, config_file, tool_shed_repository=None, guid=None, **kwds):
         raise NotImplementedError()
 
@@ -264,7 +257,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 'id': section_id,
                 'version': '',
             }
-            self.handle_panel_update(section_dict)
+            self.create_section(section_dict)
             tool_section = self._tool_panel[tool_panel_section_key]
             self._save_integrated_tool_panel()
         else:

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -562,9 +562,6 @@ class SimplifiedToolBox(ToolBox):
         # Need to start thread now for new reload callback to take effect
         self.app.watchers.start()
 
-    def handle_panel_update(self, section_dict):
-        self.create_section(section_dict)
-
 
 def reload_callback(test_case):
     test_case.app.tool_cache.cleanup()


### PR DESCRIPTION
We can just call AbstractToolBox.create_section directly as the new
install operation is atomic (thank you so much @guerler!).

We don't need to have other processes create a new section, that'll
happen when we reload the toolbox anyway. Avoids a threading issue in
some circumstances that leads to tools appearing outside of sections.
Originally I added the task message in
https://github.com/galaxyproject/galaxy/commit/51c586c264f2acd912060297804d61c2539f2483
because the install process was a two step process, where we'd first
create the tool panel section (maybe in thread1) and then place the tool
into the not-yet-existing panel section in another thread.

I tried fixing that up again in
https://github.com/galaxyproject/galaxy/commit/fb69afae28c434f35860ccaa4591e95fe3acfe91,
which I think was almost correct, but send_control_task should have been
run with `noop_self` to avoid confliciting threads updating the
sections. Anyway, this is much better now, I think.