### PR TITLE
A bit of cleanup

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -257,8 +257,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 'id': section_id,
                 'version': '',
             }
-            self.create_section(section_dict)
-            tool_section = self._tool_panel[tool_panel_section_key]
+            tool_section = self.create_section(section_dict)
             self._save_integrated_tool_panel()
         else:
             tool_section = None

--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -315,7 +315,7 @@ class JSAppLauncher(BaseUIController):
             'toolbox_in_panel'              : trans.app.toolbox.to_dict(trans),
             'message_box_visible'           : trans.app.config.message_box_visible,
             'show_inactivity_warning'       : trans.app.config.user_activation_on and trans.user and not trans.user.active,
-            'tool_shed_urls'                : trans.app.tool_shed_registry.tool_sheds.values() if trans.app.tool_shed_registry else [],
+            'tool_shed_urls'                : list(trans.app.tool_shed_registry.tool_sheds.values()) if trans.app.tool_shed_registry else [],
             'tool_dynamic_configs'          : list(trans.app.toolbox.dynamic_conf_filenames())
         }
 

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -492,12 +492,14 @@ class InstallRepositoryManager(object):
 
     def __handle_repository_contents(self, tool_shed_repository, tool_path, repository_clone_url, relative_install_dir,
                                      tool_shed=None, tool_section=None, shed_tool_conf=None, reinstalling=False,
-                                     tool_panel_section_mapping={}):
+                                     tool_panel_section_mapping=None):
         """
         Generate the metadata for the installed tool shed repository, among other things.
         This method is called when an administrator is installing a new repository or
         reinstalling an uninstalled repository.
         """
+        if tool_panel_section_mapping is None:
+            tool_panel_section_mapping = {}
         shed_config_dict = self.app.toolbox.get_shed_config_dict_by_filename(shed_tool_conf)
         stdtm = ShedToolDataTableManager(self.app)
         irmm = InstalledRepositoryMetadataManager(app=self.app,
@@ -850,7 +852,9 @@ class InstallRepositoryManager(object):
         return installed_tool_shed_repositories
 
     def install_tool_shed_repository(self, tool_shed_repository, repo_info_dict, tool_panel_section_key, shed_tool_conf, tool_path,
-                                     install_resolver_dependencies, install_tool_dependencies, reinstalling=False, tool_panel_section_mapping={}):
+                                     install_resolver_dependencies, install_tool_dependencies, reinstalling=False, tool_panel_section_mapping=None):
+        if tool_panel_section_mapping is None:
+            tool_panel_section_mapping = {}
         self.app.install_model.context.flush()
         if tool_panel_section_key:
             _, tool_section = self.app.toolbox.get_section(tool_panel_section_key)

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -620,15 +620,15 @@ class InstallRepositoryManager(object):
         tool_path = installation_dict['tool_path']
         tool_shed_url = installation_dict['tool_shed_url']
         rdim = repository_dependency_manager.RepositoryDependencyInstallManager(self.app)
-        created_or_updated_tool_shed_repositories, tool_panel_section_keys, repo_info_dicts, filtered_repo_info_dicts = \
-            rdim.create_repository_dependency_objects(tool_path=tool_path,
-                                                      tool_shed_url=tool_shed_url,
-                                                      repo_info_dicts=repo_info_dicts,
-                                                      install_repository_dependencies=install_repository_dependencies,
-                                                      no_changes_checked=no_changes_checked,
-                                                      tool_panel_section_id=tool_panel_section_id,
-                                                      new_tool_panel_section_label=new_tool_panel_section_label)
-        return created_or_updated_tool_shed_repositories, tool_panel_section_keys, repo_info_dicts, filtered_repo_info_dicts
+        return rdim.create_repository_dependency_objects(
+            tool_path=tool_path,
+            tool_shed_url=tool_shed_url,
+            repo_info_dicts=repo_info_dicts,
+            install_repository_dependencies=install_repository_dependencies,
+            no_changes_checked=no_changes_checked,
+            tool_panel_section_id=tool_panel_section_id,
+            new_tool_panel_section_label=new_tool_panel_section_label
+        )
 
     def initiate_repository_installation(self, installation_dict):
         # The following installation_dict entries are all required.
@@ -655,7 +655,7 @@ class InstallRepositoryManager(object):
             self.tpm.handle_tool_panel_section(self.app.toolbox,
                                                tool_panel_section_id=tool_panel_section_id,
                                                new_tool_panel_section_label=new_tool_panel_section_label)
-        if includes_tools_for_display_in_tool_panel and (tool_panel_section_mapping is not None):
+        if includes_tools_for_display_in_tool_panel and tool_panel_section_mapping is not None:
             for tool_guid in tool_panel_section_mapping:
                 if tool_panel_section_mapping[tool_guid]['action'] == 'create':
                     new_tool_panel_section_name = tool_panel_section_mapping[tool_guid]['tool_panel_section']

--- a/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -324,15 +324,15 @@ class ToolPanelManager(object):
         # is received, a new section will be added to the tool panel.
         if new_tool_panel_section_label:
             section_id = str(new_tool_panel_section_label.lower().replace(' ', '_'))
-            tool_panel_section_key, tool_section = \
-                self.get_or_create_tool_section(toolbox,
-                                                tool_panel_section_id=section_id,
-                                                new_tool_panel_section_label=new_tool_panel_section_label)
+            return self.get_or_create_tool_section(
+                toolbox,
+                tool_panel_section_id=section_id,
+                new_tool_panel_section_label=new_tool_panel_section_label
+            )
         elif tool_panel_section_id:
-            tool_panel_section_key, tool_section = toolbox.get_section(tool_panel_section_id)
+            return toolbox.get_section(tool_panel_section_id)
         else:
             return None, None
-        return tool_panel_section_key, tool_section
 
     def handle_tool_panel_selection(self, toolbox, metadata, no_changes_checked, tool_panel_section_id,
                                     new_tool_panel_section_label):

--- a/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -44,9 +44,11 @@ class ToolPanelManager(object):
             self.app.wait_for_toolbox_reload(old_toolbox)
 
     def add_to_tool_panel(self, repository_name, repository_clone_url, changeset_revision, repository_tools_tups, owner,
-                          shed_tool_conf, tool_panel_dict, new_install=True, tool_panel_section_mapping={}):
+                          shed_tool_conf, tool_panel_dict, new_install=True, tool_panel_section_mapping=None):
         """A tool shed repository is being installed or updated so handle tool panel alterations accordingly."""
         # We need to change the in-memory version and the file system version of the shed_tool_conf file.
+        if tool_panel_section_mapping is None:
+            tool_panel_section_mapping = {}
         shed_tool_conf_dict = self.get_shed_tool_conf_dict(shed_tool_conf)
         tool_panel_dict = self.update_tool_panel_dict(tool_panel_dict, tool_panel_section_mapping, repository_tools_tups)
         # Generate the list of ElementTree Element objects for each section or tool.


### PR DESCRIPTION
There's an off-chance that https://github.com/guerler/galaxy/commit/4db024ca1c7c3a6ca2d9af5877f8ee6d9ef4e7be would fix the issue where tools would appear in the tool panel root if you mix the new install method with the legacy or beta install method ... but I haven't been able to reproduce that.