### PR TITLE
Persist tool identity on tool_source; tighten UQ to include identity

### DIFF
--- a/lib/galaxy/managers/tool_source.py
+++ b/lib/galaxy/managers/tool_source.py
@@ -8,8 +8,10 @@ identical source text without one request later queueing with the other's
 
 ``ToolSource`` carries ``UniqueConstraint("hash", "source_class",
 "identity_hash")``, so even under concurrent inserts (PostgreSQL) at most one
-row survives; :func:`get_or_create_tool_source` retries on the unique-violation
-race to return the winner.
+row survives; :func:`get_or_create_tool_source` scopes its insert in a savepoint
+and, on the unique-violation race, rolls back just that savepoint and returns
+the winner. Scoping to a savepoint (rather than a full session rollback) keeps
+the helper safe to call from within an enclosing transaction or savepoint.
 """
 
 import hashlib
@@ -47,13 +49,16 @@ def get_or_create_tool_source(session: Session, tool) -> ToolSource:
         tool_version=tool.version,
         dynamic_tool_id=tool.dynamic_tool.id if tool.dynamic_tool else None,
     )
-    session.add(tool_source)
     try:
-        session.flush()
+        with session.begin_nested():
+            session.add(tool_source)
+            session.flush()
     except IntegrityError:
-        # Concurrent writer won the race; roll back our insert and return
-        # theirs. The unique constraint guarantees a row exists now.
-        session.rollback()
+        # Concurrent writer won the race. The savepoint rolled back only our
+        # insert, leaving the surrounding transaction intact (a full
+        # session.rollback() here would deactivate an enclosing savepoint in
+        # callers that wrap us in begin_nested()). The unique constraint
+        # guarantees a row exists now, so return theirs.
         winner = _lookup(session, content_hash, source_class, identity_hash)
         if winner is None:
             raise

--- a/lib/galaxy/managers/tool_source.py
+++ b/lib/galaxy/managers/tool_source.py
@@ -1,41 +1,51 @@
-"""Shared ToolSource lookup-or-create helper.
+"""Shared ``ToolSource`` lookup-or-create helper.
 
-A ``ToolSource`` row is content-addressable: the same persisted tool XML (or
-JSON, for CWL) under the same parser class always corresponds to one row.
-Both the async tool-request API and the workflow tool-step capture mint
-ToolRequests that point at a ToolSource, and both can share the same row
-when the tool/version is identical.
+A ``ToolSource`` row is content+identity-addressable: the same persisted tool
+source (XML, or JSON for CWL) under the same parser class and execution
+identity corresponds to one row. Distinct dynamic-tool rows can therefore carry
+identical source text without one request later queueing with the other's
+``DynamicTool``.
 
-``ToolSource`` carries a ``UniqueConstraint("hash", "source_class")``, so
-even under concurrent inserts (PostgreSQL) at most one row survives;
-:func:`get_or_create_tool_source` retries on the unique-violation race to
-return the winner.
+``ToolSource`` carries ``UniqueConstraint("hash", "source_class",
+"identity_hash")``, so even under concurrent inserts (PostgreSQL) at most one
+row survives; :func:`get_or_create_tool_source` retries on the unique-violation
+race to return the winner.
 """
 
 import hashlib
 import logging
+from typing import (
+    Any,
+    Optional,
+)
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
 from galaxy.model import ToolSource
 
 log = logging.getLogger(__name__)
 
 
-def get_or_create_tool_source(session, tool) -> ToolSource:
-    """Return a ToolSource row matching the tool's persisted source content,
-    creating one only when no equivalent row exists."""
+def get_or_create_tool_source(session: Session, tool) -> ToolSource:
+    """Return a ``ToolSource`` row matching the tool's persisted source content
+    and execution identity, creating one only when no equivalent row exists."""
     source_str = tool.tool_source.to_string()
     source_class = type(tool.tool_source).__name__
     content_hash = hashlib.sha256(source_str.encode("utf-8")).hexdigest()
-    existing = _lookup(session, content_hash, source_class)
+    identity_hash = tool_source_identity_hash(tool)
+    existing = _lookup(session, content_hash, source_class, identity_hash)
     if existing is not None:
         return existing
     tool_source = ToolSource(
         source=source_str,
         source_class=source_class,
         hash=content_hash,
+        identity_hash=identity_hash,
+        tool_id=tool.id,
+        tool_version=tool.version,
+        dynamic_tool_id=tool.dynamic_tool.id if tool.dynamic_tool else None,
     )
     session.add(tool_source)
     try:
@@ -44,14 +54,29 @@ def get_or_create_tool_source(session, tool) -> ToolSource:
         # Concurrent writer won the race; roll back our insert and return
         # theirs. The unique constraint guarantees a row exists now.
         session.rollback()
-        winner = _lookup(session, content_hash, source_class)
+        winner = _lookup(session, content_hash, source_class, identity_hash)
         if winner is None:
             raise
         return winner
     return tool_source
 
 
-def _lookup(session, content_hash: str, source_class: str):
+def tool_source_identity_hash(tool: Any) -> str:
+    dynamic_tool = getattr(tool, "dynamic_tool", None)
+    if dynamic_tool is not None and dynamic_tool.id is not None:
+        identity = ("dynamic", str(dynamic_tool.id))
+    else:
+        identity = ("static", tool.id or "", tool.version or "")
+    return hashlib.sha256("\0".join(identity).encode("utf-8")).hexdigest()
+
+
+def _lookup(session: Session, content_hash: str, source_class: str, identity_hash: str) -> Optional[ToolSource]:
     return session.scalars(
-        select(ToolSource).where(ToolSource.hash == content_hash, ToolSource.source_class == source_class).limit(1)
+        select(ToolSource)
+        .where(
+            ToolSource.hash == content_hash,
+            ToolSource.source_class == source_class,
+            ToolSource.identity_hash == identity_hash,
+        )
+        .limit(1)
     ).first()

--- a/lib/galaxy/managers/tool_source.py
+++ b/lib/galaxy/managers/tool_source.py
@@ -63,6 +63,7 @@ def get_or_create_tool_source(session: Session, tool) -> ToolSource:
 
 def tool_source_identity_hash(tool: Any) -> str:
     dynamic_tool = getattr(tool, "dynamic_tool", None)
+    identity: tuple[str, ...]
     if dynamic_tool is not None and dynamic_tool.id is not None:
         identity = ("dynamic", str(dynamic_tool.id))
     else:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1401,12 +1401,18 @@ class PasswordResetToken(Base):
 
 class ToolSource(Base, Dictifiable, RepresentById):
     __tablename__ = "tool_source"
-    __table_args__ = (UniqueConstraint("hash", "source_class"),)
+    __table_args__ = (UniqueConstraint("hash", "source_class", "identity_hash"),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
     hash: Mapped[Optional[str]] = mapped_column(Unicode(255))
     source: Mapped[dict] = mapped_column(JSONType)
     source_class: Mapped[str] = mapped_column(TrimmedString(255))
+    tool_id: Mapped[Optional[str]] = mapped_column(String(255), index=True)
+    tool_version: Mapped[Optional[str]] = mapped_column(String(255))
+    dynamic_tool_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dynamic_tool.id"), index=True)
+    identity_hash: Mapped[str] = mapped_column(String(255))
+
+    dynamic_tool: Mapped[Optional["DynamicTool"]] = relationship()
 
 
 class ToolRequest(Base, Dictifiable, RepresentById):

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/28885b317f78_add_tool_request_request_state.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/28885b317f78_add_tool_request_request_state.py
@@ -1,13 +1,29 @@
-"""Add tool_request.request_state + UNIQUE(tool_source.hash, source_class).
+"""Add tool_request.request_state + tool_source identity columns + tightened UQ.
 
-``tool_request.request_state`` records the validity of the captured request
-payload (``not_validated`` / ``validated`` / ``validation_failed``). Distinct
-from ``tool_request.state``, which tracks the async-submission lifecycle.
-Set whenever a ToolRequest is minted (async API or workflow tool step).
+Three coordinated changes:
 
-The ToolSource unique constraint enables content-addressable lookup-or-create:
-the same persisted tool source (XML/JSON) under the same parser class always
-maps to one row, regardless of how many ToolRequests reference it.
+1. ``tool_request.request_state`` records the validity of the captured request
+   payload (``not_validated`` / ``validated`` / ``validation_failed``). Distinct
+   from ``tool_request.state``, which tracks the async-submission lifecycle.
+   Set whenever a ToolRequest is minted (async API or workflow tool step).
+
+2. ``tool_source`` gains per-execution tool identity columns (``tool_id``,
+   ``tool_version``, ``dynamic_tool_id``) plus an ``identity_hash`` derived
+   from them. Tool identity now hangs off the row itself rather than being
+   recovered from the referencing ``ToolRequest``.
+
+3. ``tool_source`` UNIQUE is ``(hash, source_class, identity_hash)``. Distinct
+   dynamic-tool rows can therefore carry identical source text without sharing
+   a row, while content-identical static tools still dedupe.
+
+Existing dev DBs accumulated many ``tool_source`` rows from the async
+tool-request mint path with ``hash="TODO"`` (literal placeholder, never filled
+in). Those rows lack identity data; backfill writes the degenerate
+``identity_hash`` for ``("static", "", "")`` for them, the dedupe step
+collapses them onto the minimum-id survivor (``tool_request.tool_source_id``
+references are repointed first), and only then the UNIQUE is added.
+
+Downgrade drops the UNIQUE and the new columns; it does not un-dedupe.
 
 Revision ID: 28885b317f78
 Revises: 6925fe4c8a17
@@ -15,16 +31,24 @@ Create Date: 2026-05-21 12:30:00.000000
 
 """
 
-from sqlalchemy import (
-    Column,
-    String,
-)
+import hashlib
 
+import sqlalchemy as sa
+from alembic import op
+
+from galaxy.model.database_object_names import (
+    build_foreign_key_name,
+    build_index_name,
+)
 from galaxy.model.migrations.util import (
     add_column,
+    alter_column,
+    create_foreign_key,
+    create_index,
     create_unique_constraint,
     drop_column,
     drop_constraint,
+    drop_index,
     transaction,
 )
 
@@ -34,24 +58,130 @@ down_revision = "6925fe4c8a17"
 branch_labels = None
 depends_on = None
 
+table_name = "tool_source"
+tool_id_index_name = build_index_name(table_name, "tool_id")
+dynamic_tool_id_index_name = build_index_name(table_name, "dynamic_tool_id")
+dynamic_tool_id_fk_name = build_foreign_key_name(table_name, "dynamic_tool_id")
 # Matches what the model's naming convention (`%(table_name)s_%(column_0_name)s_key`)
 # auto-generates for the ToolSource UniqueConstraint at definition time, so an
 # init-from-model schema and a migration-built schema name the constraint the
-# same way and downgrade can locate it.
+# same way and downgrade can locate it. Widening the UQ from (hash, source_class)
+# to (hash, source_class, identity_hash) does not change the auto-name because the
+# convention only uses column 0.
 tool_source_unique_constraint_name = "tool_source_hash_key"
 
 
 def upgrade():
     with transaction():
-        add_column("tool_request", Column("request_state", String(32)))
+        add_column("tool_request", sa.Column("request_state", sa.String(32)))
+        _add_identity_columns()
+        add_column(table_name, sa.Column("identity_hash", sa.String(255), nullable=True))
+        _backfill_identity_hash()
+        alter_column(table_name, "identity_hash", nullable=False)
+        _dedupe_tool_source()
         create_unique_constraint(
             tool_source_unique_constraint_name,
-            "tool_source",
-            ["hash", "source_class"],
+            table_name,
+            ["hash", "source_class", "identity_hash"],
         )
 
 
 def downgrade():
     with transaction():
-        drop_constraint(tool_source_unique_constraint_name, "tool_source")
+        drop_constraint(tool_source_unique_constraint_name, table_name)
+        drop_column(table_name, "identity_hash")
+        _drop_identity_columns()
         drop_column("tool_request", "request_state")
+
+
+def _add_identity_columns():
+    add_column(table_name, sa.Column("tool_id", sa.String(255), nullable=True, default=None))
+    create_index(tool_id_index_name, table_name, ["tool_id"])
+    add_column(table_name, sa.Column("tool_version", sa.String(255), nullable=True, default=None))
+    add_column(table_name, sa.Column("dynamic_tool_id", sa.Integer, nullable=True, default=None))
+    create_index(dynamic_tool_id_index_name, table_name, ["dynamic_tool_id"])
+    create_foreign_key(dynamic_tool_id_fk_name, table_name, "dynamic_tool", ["dynamic_tool_id"], ["id"])
+
+
+def _drop_identity_columns():
+    drop_constraint(dynamic_tool_id_fk_name, table_name)
+    drop_index(dynamic_tool_id_index_name, table_name)
+    drop_column(table_name, "dynamic_tool_id")
+    drop_column(table_name, "tool_version")
+    drop_index(tool_id_index_name, table_name)
+    drop_column(table_name, "tool_id")
+
+
+def _backfill_identity_hash() -> None:
+    conn = op.get_bind()
+    rows = list(
+        conn.execute(
+            sa.text(f"SELECT id, tool_id, tool_version, dynamic_tool_id FROM {table_name} ORDER BY id")
+        ).mappings()
+    )
+    for row in rows:
+        conn.execute(
+            sa.text(f"UPDATE {table_name} SET identity_hash = :identity_hash WHERE id = :id"),
+            {"identity_hash": _identity_hash_for_row(row), "id": row["id"]},
+        )
+
+
+def _identity_hash_for_row(row) -> str:
+    dynamic_tool_id = row["dynamic_tool_id"]
+    if dynamic_tool_id is not None:
+        identity = ("dynamic", str(dynamic_tool_id))
+    else:
+        identity = ("static", row["tool_id"] or "", row["tool_version"] or "")
+    return hashlib.sha256("\0".join(identity).encode("utf-8")).hexdigest()
+
+
+def _dedupe_tool_source() -> None:
+    """Repoint ``tool_request.tool_source_id`` at the minimum-id row per
+    (hash, source_class, identity_hash) group, then delete loser rows.
+
+    Pre-rollout DBs typically carry many ``hash="TODO"`` rows from the async
+    mint path; they collapse onto one survivor here. SQL is written to work
+    on both PostgreSQL and SQLite (correlated subqueries only — no
+    UPDATE...FROM, no window functions in DELETE).
+    """
+    op.execute("""
+        UPDATE tool_request
+        SET tool_source_id = (
+            SELECT MIN(ts2.id) FROM tool_source ts2
+            WHERE ts2.hash = (
+                SELECT ts1.hash FROM tool_source ts1
+                WHERE ts1.id = tool_request.tool_source_id
+            )
+            AND ts2.source_class = (
+                SELECT ts1.source_class FROM tool_source ts1
+                WHERE ts1.id = tool_request.tool_source_id
+            )
+            AND ts2.identity_hash = (
+                SELECT ts1.identity_hash FROM tool_source ts1
+                WHERE ts1.id = tool_request.tool_source_id
+            )
+        )
+        WHERE tool_source_id IN (
+            SELECT id FROM tool_source ts
+            WHERE EXISTS (
+                SELECT 1 FROM tool_source ts2
+                WHERE ts2.hash = ts.hash
+                  AND ts2.source_class = ts.source_class
+                  AND ts2.identity_hash = ts.identity_hash
+                  AND ts2.id < ts.id
+            )
+        )
+    """)
+    op.execute("""
+        DELETE FROM tool_source
+        WHERE id IN (
+            SELECT id FROM tool_source ts
+            WHERE EXISTS (
+                SELECT 1 FROM tool_source ts2
+                WHERE ts2.hash = ts.hash
+                  AND ts2.source_class = ts.source_class
+                  AND ts2.identity_hash = ts.identity_hash
+                  AND ts2.id < ts.id
+            )
+        )
+    """)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/28885b317f78_add_tool_request_request_state.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/28885b317f78_add_tool_request_request_state.py
@@ -128,6 +128,7 @@ def _backfill_identity_hash() -> None:
 
 def _identity_hash_for_row(row) -> str:
     dynamic_tool_id = row["dynamic_tool_id"]
+    identity: tuple[str, ...]
     if dynamic_tool_id is not None:
         identity = ("dynamic", str(dynamic_tool_id))
     else:

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -39,6 +39,10 @@ from galaxy.util.permutations import (
 )
 from galaxy.work.context import WorkRequestContext
 from . import visit_input_values
+from .workflow_utils import (
+    runtime_to_json,
+    RuntimeValue,
+)
 from .wrapped import process_key
 from .._types import (
     InputFormatT,
@@ -412,6 +416,8 @@ def to_decoded_json(has_objects):
         return {"src": "hdca", "id": has_objects.id}
     elif isinstance(has_objects, LibraryDatasetDatasetAssociation):
         return {"src": "ldda", "id": has_objects.id}
+    elif isinstance(has_objects, RuntimeValue):
+        return runtime_to_json(has_objects)
     else:
         return has_objects
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2433,6 +2433,11 @@ def _capture_workflow_tool_request_state(
     if request_internal is None:
         return None, None, None
 
+    # Persistence is best-effort and execution-neutral: an exception here
+    # (e.g. ``tool.tool_source.to_string()`` on a tool with no serializable
+    # source, or a unique-constraint race we cannot recover) must not abort
+    # workflow scheduling. Savepoint scopes the flush so a failure rolls back
+    # to clean transaction state instead of poisoning the outer session.
     try:
         with trans.sa_session.begin_nested():
             tool_source = get_or_create_tool_source(trans.sa_session, tool)
@@ -2440,6 +2445,10 @@ def _capture_workflow_tool_request_state(
             tool_request.request = request_internal.input_state
             tool_request.tool_source = tool_source
             tool_request.history = history
+            # `state` is the async-submission lifecycle (NEW/SUBMITTED/FAILED)
+            # and does not apply to workflow-minted records; left NULL so
+            # consumers can distinguish "captured workflow state" from
+            # "pending async submission".
             tool_request.request_state = request_state.value
             trans.sa_session.add(tool_request)
     except Exception as e:

--- a/test/unit/app/managers/test_HistoryGraphBuilder.py
+++ b/test/unit/app/managers/test_HistoryGraphBuilder.py
@@ -75,10 +75,11 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
 
     def _create_tool_source(self):
         ts = model.ToolSource()
-        # Unique per call — tool_source has a UNIQUE(hash, source_class) constraint.
+        # Unique per call — tool_source has a UNIQUE(hash, source_class, identity_hash) constraint.
         ts.hash = uuid4().hex
         ts.source = {"xml": "<tool/>"}
         ts.source_class = "XmlToolSource"
+        ts.identity_hash = uuid4().hex
         session = self.trans.sa_session
         session.add(ts)
         session.flush()
@@ -1235,10 +1236,11 @@ class TestHistoryGraphBuilderBoundedness(BaseTestCase, CreatesCollectionsMixin):
 
     def _create_tool_source(self):
         ts = model.ToolSource()
-        # Unique per call — tool_source has a UNIQUE(hash, source_class) constraint.
+        # Unique per call — tool_source has a UNIQUE(hash, source_class, identity_hash) constraint.
         ts.hash = uuid4().hex
         ts.source = {"xml": "<tool/>"}
         ts.source_class = "XmlToolSource"
+        ts.identity_hash = uuid4().hex
         session = self.trans.sa_session
         session.add(ts)
         session.flush()

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -12,7 +12,12 @@ import pytest
 from galaxy import model
 from galaxy.managers.workflows import WorkflowContentsManager
 from galaxy.tool_util.parser.output_objects import ToolOutput
-from galaxy.tools.parameters.workflow_utils import NO_REPLACEMENT
+from galaxy.tools.parameters.meta import to_decoded_json
+from galaxy.tools.parameters.workflow_utils import (
+    ConnectedValue,
+    NO_REPLACEMENT,
+    RuntimeValue,
+)
 from galaxy.util import bunch
 from galaxy.workflow import modules
 from .workflow_support import (
@@ -670,3 +675,31 @@ def test_capture_unexpected_error_returns_none_loudly():
         assert _capture(resolve) == (None, None, None)
 
     log.warning.assert_called_once()
+
+
+def test_to_decoded_json_lowers_connected_value_in_repeat():
+    """ConnectedValue inside a repeat lowers to its JSON marker.
+
+    Regression: an unresolved connection inside a `repeat` survived to the
+    tool_request flush as a raw ``ConnectedValue()`` and broke JSON encode
+    with a TypeError. ``to_decoded_json`` recurses and lowers it to a marker.
+    """
+    payload = {
+        "datasets": [
+            {"input": {"src": "hda", "id": 1}},
+            {"input": ConnectedValue()},
+        ],
+    }
+
+    result = to_decoded_json(payload)
+
+    assert result["datasets"][0]["input"] == {"src": "hda", "id": 1}
+    assert result["datasets"][1]["input"] == {"__class__": "ConnectedValue"}
+    json.dumps(result)
+
+
+def test_to_decoded_json_lowers_bare_runtime_value():
+    """Bare RuntimeValue tokens lower to their JSON marker form too."""
+    result = to_decoded_json({"foo": RuntimeValue()})
+    assert result == {"foo": {"__class__": "RuntimeValue"}}
+    json.dumps(result)


### PR DESCRIPTION
Add tool_id/tool_version/dynamic_tool_id columns to tool_source, plus an identity_hash derived from them. Tool identity hangs off the row itself rather than being recovered through the referencing ToolRequest, so distinct dynamic-tool rows can carry identical source text without one request later queueing with another's DynamicTool.

UNIQUE(hash, source_class) widens to UNIQUE(hash, source_class, identity_hash). The migration backfills identity_hash on existing rows (degenerate for pre-rollout hash="TODO" rows that lack identity data), dedupes by the wider key with tool_request.tool_source_id repointed at the minimum-id survivor, then adds the UNIQUE.

get_or_create_tool_source now keys lookup on identity as well and populates the identity columns on inserts.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
